### PR TITLE
plugin.xml :: update cordova-plugin-file dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,7 @@
     <repo>https://github.com/solderzzc/cordova-plugin-file-transfer.git</repo>
     <issue></issue>
 
-    <!-- dependency id="org.apache.cordova.file@1" /-->
-    <dependency id="org.apache.cordova.file" version=">=1.0.1" />
+    <dependency id="cordova-plugin-file" version=">=1.0.1" />
 
     <js-module src="www/FileTransferBCSError.js" name="FileTransferBCSError">
         <clobbers target="window.FileTransferBCSError" />


### PR DESCRIPTION
The official cordova plugins have been migrated to NPM and IDs have been
changed.

http://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html
